### PR TITLE
Restore no-args constructor

### DIFF
--- a/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTest.java
+++ b/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTest.java
@@ -23,6 +23,10 @@ import org.junit.BeforeClass;
  */
 public abstract class XtextTest extends XtextTestBase {
 
+    public XtextTest() {
+        super();
+    }
+
     public XtextTest(String uri) {
         super(uri);
     }


### PR DESCRIPTION
Restore the no-args constructor that was probably removed by accident in https://github.com/itemis/xtext-testing/commit/d4954482017cc8ee7b8b9d509bcbde5d26f3c080 when XtestTest was refactored into XtextTest and XtextTestBase. 

This PR initiated as a discussion on: https://www.eclipse.org/forums/index.php?t=msg&th=1082513&goto=1748324&#msg_1748324
