### PR TITLE
Add junit5 support

### DIFF
--- a/plugins/com.itemis.xtext.testing/.classpath
+++ b/plugins/com.itemis.xtext.testing/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/plugins/com.itemis.xtext.testing/META-INF/MANIFEST.MF
+++ b/plugins/com.itemis.xtext.testing/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: com.google.inject;visibility:=reexport,
  org.eclipse.xtext;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.xtext.util;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
- org.junit;bundle-version="4.8.1";visibility:=reexport,
+ org.eclipse.xtext.testing;bundle-version="2.15.0",
  org.eclipse.xtext.junit4;bundle-version="2.0.0"
 Import-Package: org.apache.commons.logging,
  org.apache.log4j

--- a/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTest.java
+++ b/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTest.java
@@ -1,6 +1,7 @@
 package com.itemis.xtext.testing;
 
 import org.eclipse.emf.mwe.utils.StandaloneSetup;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.BeforeClass;
 
 /**
@@ -20,6 +21,7 @@ import org.junit.BeforeClass;
  * @author Markus Voelter
  * @author Alexander Nittka
  * @author Vlad Dumitrescu
+ * @author Marius Weth
  *
  */
 public abstract class XtextTest extends XtextTestBase {
@@ -32,6 +34,7 @@ public abstract class XtextTest extends XtextTestBase {
         super(uri);
     }
 
+    @BeforeAll
     @BeforeClass
     public static void init_internal() {
         new StandaloneSetup().setPlatformUri("..");

--- a/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTestBase.java
+++ b/plugins/com.itemis.xtext.testing/src/com/itemis/xtext/testing/XtextTestBase.java
@@ -1,9 +1,11 @@
 package com.itemis.xtext.testing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,9 +46,13 @@ import org.eclipse.xtext.util.Pair;
 import org.eclipse.xtext.util.Tuples;
 import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.Issue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
+
+
 
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
@@ -68,6 +74,7 @@ import com.google.inject.Inject;
  * @author Markus Voelter
  * @author Alexander Nittka
  * @author Vlad Dumitrescu
+ * @author Marius Weth
  *
  */
 public abstract class XtextTestBase {
@@ -133,6 +140,7 @@ public abstract class XtextTestBase {
     public void before() {
     }
 
+    @BeforeEach
     @Before
     public final void _before() {
         issues = null;
@@ -169,11 +177,12 @@ public abstract class XtextTestBase {
     }
 
     @After
+    @AfterEach
     public void _after() {
         if (issues != null) {
             dumpUnassertedIssues();
             if (issues.except(assertedIssues).getIssues().size() != 0) {
-                Assert.fail("\n\nfound unasserted issues "
+                Assertions.fail("\n\nfound unasserted issues "
                         + issues.except(assertedIssues).getSummary() + "\n\n");
             }
         }
@@ -344,7 +353,7 @@ public abstract class XtextTestBase {
     protected void testTerminal(final String input,
             final String... expectedTerminals) {
         final List<Token> tokens = getTokens(input);
-        assertEquals(input, expectedTerminals.length, tokens.size());
+        assertEquals(expectedTerminals.length, tokens.size(),input);
         for (int i = 0; i < tokens.size(); i++) {
             final Token token = tokens.get(i);
             String exp = expectedTerminals[i];
@@ -366,8 +375,8 @@ public abstract class XtextTestBase {
 
         String tokenType = getTokenType(token);
 
-        assertFalse(input,
-                tokens.size() == 1 && tokenType != null && tokenType.equals("RULE_" + unexpectedTerminal));
+        assertFalse(tokens.size() == 1 && tokenType != null && tokenType.equals("RULE_" + unexpectedTerminal),
+                input);
     }
 
     /**
@@ -386,9 +395,9 @@ public abstract class XtextTestBase {
      */
     protected void testNoKeyword(final String keyword) {
         final List<Token> tokens = getTokens(keyword);
-        assertEquals(keyword, 1, tokens.size());
+        assertEquals(1, tokens.size(),keyword);
         final String type = getTokenType(tokens.get(0));
-        assertFalse(keyword, type.charAt(0) == '\'');
+        assertFalse(type.charAt(0) == '\'',keyword);
     }
 
     protected String loadFileContents(final String rootPath,
@@ -499,8 +508,8 @@ public abstract class XtextTestBase {
             fail("\n\n" + failMessage + "\n");
         }
 
-        assertFalse("Resource has no content",
-                resource.getContents().isEmpty());
+        assertFalse(resource.getContents().isEmpty(),
+                "Resource has no content");
         final EObject o = resource.getContents().get(0);
         // assure that the root element is of the expected type
         if (clazz != null) {
@@ -598,16 +607,16 @@ public abstract class XtextTestBase {
         ensureIsAfterTestFile();
 
         assertedIssues.addAll(coll.getIssues());
-        Assert.assertTrue("failed " + msg + coll.getMessageString(),
-                coll.evaluate());
+        Assertions.assertTrue(coll.evaluate(),
+                "failed " + msg + coll.getMessageString());
     }
 
     protected void assertConstraints(final FluentIssueCollection coll) {
         ensureIsAfterTestFile();
 
         assertedIssues.addAll(coll.getIssues());
-        Assert.assertTrue("<no id> failed" + coll.getMessageString(),
-                coll.evaluate());
+        Assertions.assertTrue(coll.evaluate(),
+                "<no id> failed" + coll.getMessageString());
     }
 
     protected void assertConstraints(final String constraintID,
@@ -615,8 +624,8 @@ public abstract class XtextTestBase {
         ensureIsAfterTestFile();
 
         assertedIssues.addAll(coll.getIssues());
-        Assert.assertTrue(constraintID + " failed" + coll.getMessageString(),
-                coll.evaluate());
+        Assertions.assertTrue(coll.evaluate(),
+                constraintID + " failed" + coll.getMessageString());
     }
 
     public EObject getEObject(final URI uri) {


### PR DESCRIPTION
- Add org.eclipse.xtext.testing dependency in MANIFEST.MF
- Add junit5 annotations in XtextTest.java and XtextTestBase.java
- Add org.eclipse.junit.JUNIT_CONTAINER/5 in .classpath